### PR TITLE
Add Spanish System (eo variant) plugin

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -36,6 +36,7 @@
   "plover-russian-trillo",
   "plover-space-config",
   "plover-spanish-mqd",
+  "plover-spanish-system-eo-variant",
   "plover-splits",
   "plover-start-words",
   "plover-stenograph-usb",


### PR DESCRIPTION
Includes Spanish System (eo variant) plugin: https://github.com/roskoff/plover_spanish_system_eo_variant