### PR TITLE
Remove space config plugin

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -38,7 +38,6 @@
   "plover-retro-text-transform",
   "plover-run-shell",
   "plover-russian-trillo",
-  "plover-space-config",
   "plover-spanish-mqd",
   "plover-spanish-system-eo-variant",
   "plover-splits",


### PR DESCRIPTION
Looks like the [github repo](https://github.com/pea/plover_space_config) for this plugin is gone, possibly because we added a generic config-changing meta.