### PR TITLE
Add plover-clr-trans-state

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -4,6 +4,7 @@
   "plover-casecat-dictionary",
   "plover-cat",
   "plover-clippy",
+  "plover-clr-trans-state",
   "plover-console-ui",
   "plover-current-time",
   "plover-dict-commands",


### PR DESCRIPTION
This plugin provides a command that clears the translation state (useful when switching between applications).
See: https://pypi.org/project/plover-clr-trans-state