### PR TITLE
Add alleycat-link

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,4 +1,5 @@
 [
+  "alleycat-link",
   "plover-auto-identifier",
   "plover-cards",
   "plover-casecat-dictionary",


### PR DESCRIPTION
`alleycat-link` is part of [AlleyCAT](https://github.com/sammdot/alleycat), the CAT system I'm working on. It allows AlleyCAT to connect to Plover through a TCP connection. In the future I'd like to move this to a Unix domain socket or Windows named pipe, but the protocol implementation is there and it can be used in its current state.