### PR TITLE
cycle-homophones and split-at−apostrophe

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -91,5 +91,7 @@
   "plover-wpm-meter",
   "plover-xtest-input",
   "plover-yaml-dictionary",
-  "spectra-lexer"
+  "spectra-lexer",
+  "plover-split-at-apostrophe",
+  "plover-cycle-homophones"
 ]


### PR DESCRIPTION
Hello,
I'm making my first contribution to the registry with these two plugins. 
They are meant to be used with my modded-Grandjean system. I'll be making another PR in the upcoming days to also add my Grandjean system to the registry.

Please let me know if there's anything I've missed in the process of updating the registry.

The two current plugins can be found at:
https://pypi.org/project/plover-cycle-homophones/0.0.1/ https://pypi.org/project/plover-split-at-apostrophe/0.0.5/

Best regards,

Antoine