### PR TITLE
new plugin: plover-wtype-output

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -92,6 +92,7 @@
   "plover-vlc-commands",
   "plover-windows-brightness",
   "plover-word-tray",
+  "plover-wtype-output",
   "plover-wpm-meter",
   "plover-xtest-input",
   "plover-yaml-dictionary",


### PR DESCRIPTION
allows for unicode on wayland