### PR TITLE
add plover-auto-reconnect-machine

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,7 @@
 [
   "alleycat-link",
   "plover-auto-identifier",
+  "plover-auto-reconnect-machine",
   "plover-cards",
   "plover-casecat-dictionary",
   "plover-cat",


### PR DESCRIPTION
This plugin works with plover 4.0.0rc2 and above (because it depends on https://github.com/openstenoproject/plover/pull/1636). After adding and enabling it, it automatically reconnects the current steno machine after the connection has been lost, e.g. after suspend of the PC or manually unplugging the machine.