### PR TITLE
Remove layout-display plugin

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -32,7 +32,6 @@
   "plover-json-lazy",
   "plover-lapwing-aio",
   "plover-last-translation",
-  "plover-layout-display",
   "plover-local-env-var",
   "plover-maajik",
   "plover-markdown-dictionary",


### PR DESCRIPTION
Installation causes issues with the plugins manager disappearing. I suggest removing it and recommending the svg layout display plugin instead.