### PR TITLE
:heavy_plus_sign: Add plover-websocket-server plugin.

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -93,6 +93,7 @@
   "plover-unused-xtest-output",
   "plover-vcs-plugin",
   "plover-vlc-commands",
+  "plover-websocket-server",
   "plover-windows-brightness",
   "plover-word-tray",
   "plover-wpm-meter",


### PR DESCRIPTION
Add plover-websocket-server plugin from https://github.com/CosmicDNA/plover-websocket-server. This plugin is being used by https://github.com/CosmicDNA/touchscreen-stenography-keyboard.