### PR TITLE
Remove plover-uinput-output

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -87,7 +87,6 @@
   "plover-textarea",
   "plover-trayicon",
   "plover-treal",
-  "plover-uinput-output",
   "plover-unused-xtest-output",
   "plover-vcs-plugin",
   "plover-vlc-commands",


### PR DESCRIPTION
`plover-uinput-output` is unmaintained and is not working with the current version of Plover.
We should replace it with `plover-uinput` instead as in #50 (should https://github.com/openstenoproject/plover/pull/1679 not be merged).