### PR TITLE
Add plover-cycle-translations plugin to the registry

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -13,6 +13,7 @@
   "plover-console-ui",
   "plover-controller",
   "plover-current-time",
+  "plover-cycle-translations",
   "plover-debugging-console",
   "plover-delay",
   "plover-dict-commands",


### PR DESCRIPTION
Adds the [Plover Cycle Translations](https://github.com/paulfioravanti/plover-cycle-translations) plugin to the registry.