### PR TITLE
Add plover-steno-engine-hooks-logger plugin to the registry

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -76,6 +76,7 @@
   "plover-splits",
   "plover-start-words",
   "plover-startup-py",
+  "plover-steno-engine-hooks-logger",
   "plover-stenobee",
   "plover-stenograph",
   "plover-stenohid-test",


### PR DESCRIPTION
Adds [Plover Steno Engine Hooks Logger](https://github.com/paulfioravanti/plover-steno-engine-hooks-logger) to the registry.