### PR TITLE
replace plover-casecat-dictionary with plover-casecat

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -5,7 +5,7 @@
   "plover-auto-identifier",
   "plover-auto-reconnect-machine",
   "plover-cards",
-  "plover-casecat-dictionary",
+  "plover-casecat",
   "plover-cat",
   "plover-clippy",
   "plover-clippy-2",


### PR DESCRIPTION
Not sure what was wrong with the original one, since the code looked correct but none of the entries were showing up. [`plover-casecat`](https://github.com/sammdot/plover-casecat) has been updated with additional opcodes that may be useful for Plover users.