### PR TITLE
:heavy_plus_sign: Add plover-touch-tablets plugin.

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -95,6 +95,7 @@
   "plover_system_switcher",
   "plover-tapey-tape",
   "plover-textarea",
+  "plover-touch-tablets",
   "plover-trayicon",
   "plover-treal",
   "plover-uinput",


### PR DESCRIPTION
Add [plover-touch-tablets plugin](https://github.com/CosmicDNA/plover-touch-tablets) to the registry.

This plugin is compatible with [touch-steno-keyboard](https://github.com/CosmicDNA/touch-steno-keyboard) and with [plover-websocket-relay](https://github.com/CosmicDNA/plover-websocket-relay).